### PR TITLE
Only set the JWT UUID if it is not already set

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -24,8 +24,12 @@ export function createJWT (payload = {}, options = {}) {
     'sub',
     'iss'
   ];
-  const settings = merge({ jwtid: uuidv4() }, options.jwt);
+  const settings = merge({}, options.jwt);
   const { secret } = options;
+
+  if (!(payload.jti || settings.jwtid)) {
+    settings.jwtid = uuidv4();
+  }
 
   return new Promise((resolve, reject) => {
     debug('Creating JWT using options', settings);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -63,6 +63,17 @@ describe('utils', () => {
       });
     });
 
+    it('does not error if payload has jti property', () => {
+      return createJWT({
+        id: 1,
+        jti: 'test'
+      }, options).then(t => {
+        const decoded = jwt.decode(t);
+
+        expect(decoded.jti).to.equal('test');
+      });
+    });
+
     describe('when passing custom options', () => {
       let token;
       let decoded;


### PR DESCRIPTION
This is a regression of #539. Basically if you were creating a new token using an existing JWT you always got an error since the `jti` property is already set in the original payload.

Closes https://github.com/feathersjs/authentication-jwt/issues/43