### PR TITLE
Options merged

### DIFF
--- a/lib/socket/handler.js
+++ b/lib/socket/handler.js
@@ -1,6 +1,8 @@
 const Debug = require('debug');
 const ms = require('ms');
 
+const merge = require('lodash.merge');
+
 const {
   normalizeError
 } = require('@feathersjs/socket-commons/lib/utils');
@@ -79,7 +81,7 @@ module.exports = function setupSocketHandler (app, options, { feathersParams, pr
         cookies: {}
       }, feathersParams(socket));
 
-      const strategyOptions = app.passport.options(strategy);
+      const strategyOptions = merge({}, app.passport.options(strategy), options);
 
       const promise = service.create(data, socket._feathers)
         .then(tokens => {

--- a/lib/socket/handler.js
+++ b/lib/socket/handler.js
@@ -81,7 +81,7 @@ module.exports = function setupSocketHandler (app, options, { feathersParams, pr
         cookies: {}
       }, feathersParams(socket));
 
-      const strategyOptions = merge({}, app.passport.options(strategy), options);
+      const strategyOptions = merge({}, options, app.passport.options(strategy));
 
       const promise = service.create(data, socket._feathers)
         .then(tokens => {


### PR DESCRIPTION
When trying to authenticate through sockets, options are not merged [(socket/handler.js#L82),](https://github.com/feathersjs/authentication/blob/master/lib/socket/handler.js#L82) such as hooks [hooks/authenticate.js#L55](https://github.com/feathersjs/authentication/blob/master/lib/hooks/authenticate.js#L55)

This can cause the following error if you try to define and use custom strategy:

`TypeError: Cannot read property 'entity' of undefined at service.create.then.tokens (@feathersjs\authentication\lib\socket\handler.js:95:31)`