### PR TITLE
Allow the ability to specify a custom service to be used

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,9 +49,11 @@ function init (config = {}) {
       app.use(express.exposeCookies());
     }
 
-    // TODO (EK): Support passing your own service or force
-    // developer to register it themselves.
-    app.configure(service(options));
+    if (typeof config.service === 'function') {
+      app.configure(config.service(options));
+    } else {
+      app.configure(service(options));
+    }
     app.passport.initialize();
 
     app.setup = function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -130,6 +130,19 @@ describe('Feathers Authentication', () => {
     expect(app.service('authentication')).to.not.equal(undefined);
   });
 
+  it('registers the custom authentication service', () => {
+    config.service = function(options) {
+      return () => {
+        app.use(options.path, {
+          get: id => []
+        });
+      };
+    };
+
+    app.configure(authentication(config));
+    expect(app.service('authentication')).to.not.equal(undefined);
+  });
+
   describe('when cookies are enabled', () => {
     it('registers the express exposeCookies middleware', () => {
       config = Object.assign(config, { cookie: { enabled: true } });


### PR DESCRIPTION
When passing the config to the configure function for authentication you can provide a function, similar to how most services are created, that registers a custom service under the property `service`.
```js
config.service = function(options) {
  return () => {
    app.use(options.path, {
      get: id => []
    });
  };
};

app.configure(authentication(config));
```
This will not register the original, default, service that is normally created, instead it will set the `authentication` service to the one specified under the `service` property within the config.

> Support passing your own service or force developer to register it themselves.

Reading that comment, which was originally within the code, I'm not completely sure if this the preferred solution, but it is _a solution_; if that's the case then I'm willing to make any changes to move to a more preferred method.