### PR TITLE
Fix setTimeout memory leak

### DIFF
--- a/src/socket/handler.js
+++ b/src/socket/handler.js
@@ -23,10 +23,9 @@ export default function setupSocketHandler (app, options, { feathersParams, prov
   const service = app.service(authSettings.path);
   const entityService = app.service(authSettings.service);
   let isUpdateEntitySetup = false;
+  let logoutTimer;
 
   return function (socket) {
-    let logoutTimer;
-
     const logout = function (callback = () => {}) {
       const connection = feathersParams(socket);
       const { accessToken } = connection;
@@ -50,6 +49,9 @@ export default function setupSocketHandler (app, options, { feathersParams, prov
 
           return tokens;
         });
+
+        // Clear logoutTimer.
+        lt.clearTimeout(logoutTimer);
 
         handleSocketCallback(promise, callback);
       } else if (typeof callback === 'function') {
@@ -98,12 +100,6 @@ export default function setupSocketHandler (app, options, { feathersParams, prov
               socket,
               connection
             });
-          }
-
-          // Clear any previous timeout if we have logged in again.
-          if (logoutTimer) {
-            debug(`Clearing old timeout.`);
-            lt.clearTimeout(logoutTimer);
           }
 
           logoutTimer = lt.setTimeout(() => {

--- a/src/socket/handler.js
+++ b/src/socket/handler.js
@@ -23,9 +23,10 @@ export default function setupSocketHandler (app, options, { feathersParams, prov
   const service = app.service(authSettings.path);
   const entityService = app.service(authSettings.service);
   let isUpdateEntitySetup = false;
-  let logoutTimer;
 
   return function (socket) {
+    let logoutTimer;
+
     const logout = function (callback = () => {}) {
       const connection = feathersParams(socket);
       const { accessToken } = connection;
@@ -100,6 +101,12 @@ export default function setupSocketHandler (app, options, { feathersParams, prov
               socket,
               connection
             });
+          }
+
+          // Clear any previous timeout if we have logged in again.
+          if (logoutTimer) {
+            debug(`Clearing old timeout.`);
+            lt.clearTimeout(logoutTimer);
           }
 
           logoutTimer = lt.setTimeout(() => {


### PR DESCRIPTION
### Steps to reproduce
- login user -> logout user
- login user -> user disconnected ->  re-authenticate user

### Expected behavior
- previous logoutTimer (setTimeout) should be cleared

### Actual behavior
- logoutTimer still stays

### Reason
- this one will never be true https://github.com/feathersjs/authentication/blob/master/lib/socket/handler.js#L110 if the user was disconnected then tried to re-authenticate.

-  should clear the timeout here too https://github.com/feathersjs/authentication/blob/master/lib/socket/handler.js#L59 when socket is disconnected and user tried to reauthenticate.

![screen shot 2018-03-16 at 5 05 26 pm](https://user-images.githubusercontent.com/4872417/37522727-cc5cded0-295f-11e8-8d0b-fe7c737a550d.png)

![screen shot 2018-03-16 at 5 06 17 pm](https://user-images.githubusercontent.com/4872417/37522761-e7a21ebc-295f-11e8-83a3-bf52511cc91a.png)

