### PR TITLE
Return the original accessToken for jwt authentication

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -14,6 +14,12 @@ class Service {
     const defaults = this.app.get('authentication') || this.app.get('auth');
     const payload = params.payload;
 
+    if (data.strategy === 'jwt') {
+      return Promise.resolve({
+        accessToken: data.accessToken
+      });
+    }
+
     // create accessToken
     // TODO (EK): Support refresh tokens
     // TODO (EK): This should likely be a hook

--- a/test/hooks/authenticate.test.js
+++ b/test/hooks/authenticate.test.js
@@ -43,9 +43,12 @@ describe('hooks:authenticate', () => {
 
   describe('when strategy name is missing', () => {
     it('throws an error', () => {
-      expect(() => {
+      try {
         authenticate()(hook);
-      }).to.throw;
+        throw new Error('Should never get here');
+      } catch (e) {
+        expect(e.message).to.equal('The \'authenticate\' hook requires one of your registered passport strategies.');
+      }
     });
   });
 

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -79,6 +79,17 @@ describe('/authentication service', () => {
       });
     });
 
+    it('returns existing accessToken when strategy is JWT', () => {
+      const accessToken = 'something';
+
+      return app.service('authentication').create({
+        strategy: 'jwt',
+        accessToken
+      }).then(result => {
+        expect(result).to.deep.equal({ accessToken });
+      });
+    });
+
     it('creates a custom token', () => {
       const params = {
         jwt: {


### PR DESCRIPTION
It is possible to authenticate using JWT which currently returned a new token. The original intention was to validate and return the existing token.

For https://github.com/feathersjs/authentication-jwt/issues/61