### PR TITLE
Drop subject from the default configuration

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -16,7 +16,6 @@ const defaults = {
   jwt: {
     header: { typ: 'access' }, // by default is an access token but can be any type
     audience: 'https://yourdomain.com', // The resource server where the token is processed
-    subject: 'anonymous', // Typically the entity id associated with the JWT
     issuer: 'feathers', // The issuing server, application or resource
     algorithm: 'HS256',
     expiresIn: '1d'

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -73,7 +73,7 @@ describe('options', () => {
       });
 
       it('sets the subject', () => {
-        expect(options.jwt.subject).to.equal('anonymous');
+        expect(options.jwt.subject).to.equal(undefined);
       });
 
       it('sets the issuer', () => {


### PR DESCRIPTION
There are multiple issues with setting default subject to anonymous.

First, it is close to impossible to unset this option from user
application. It is mixed in with lodash.merge which does not provide
any way to unset values.

Second, from RFC 7519 (JSON Web Token):

> 4.1.2.  "sub" (Subject) Claim
>
>    The "sub" (subject) claim identifies the principal that is the
>    subject of the JWT.  The claims in a JWT are normally statements
>    about the subject.  The subject value MUST either be scoped to be
>    locally unique in the context of the issuer or be globally unique.
>    The processing of this claim is generally application specific.  The
>    "sub" value is a case-sensitive string containing a StringOrURI
>    value.  Use of this claim is OPTIONAL.

The default "anonymous" value is not unique. (Neither is any constant
value the user could set in service configuration.) "sub" claim is
optional, so dropping it creates perfectly valid JWT.

Third (and main reason for me), this breaks badly when trying to use
"sub" claim for its purpose—carrying entity id.

Here is a quick snippet:
```js
app.service('authentication').hooks({
  before: {
    create: [
      authentication.hooks.authenticate(config.strategies),

      // Enrich JWT token with user info
      (context) => {
        const user = context.params.user;
        context.params.jwt = context.params.jwt || {};
        context.params.jwt.subject = user.id;
      },
    ],

    remove: [authentication.hooks.authenticate('jwt')],
  },
});
```

This overrides subject for create method, so I get sub claim I
want.

Unfortunately, this causes remove method to fail loudly with:
```
error: JsonWebTokenError: jwt subject invalid. expected: anonymous
```

Here is what happens:

lib/service.js:35:
```js
    return this.passport
      .verifyJWT(accessToken, merge(defaults, params))
      .then(payload => {
        return { accessToken };
      });
```

verifyJWT is fed with `subject: anonymous` from defaults, so it
tries to verify the sub claim to be anonymous.

I could possibly add a hook to do the same trick in
before-remove (after authenticate('jwt')):
```js
(context) => {
  const user = context.params.user;
  context.params.jwt = context.params.jwt || {};
  context.params.jwt.subject = user.id;
}
```

But that does not work because context.params.user is not set.

lib/socket/handler.js:52
```js
const promise = service.remove(accessToken, { authenticated: true }).then(tokens => {
```

lib/hooks/authenticate.js:17
```js
// If called internally or we are already authenticated skip
if (!hook.params.provider || hook.params.authenticated) {
  return Promise.resolve(hook);
}
```

The handler passes `authenticated: true` in, so authenticate('jwt')
short-exits without setting the user.

I could possibly decode JWT token myself, pull sub out and populate
context.jwt.subject, but hey! that should have worked out of the box!

Removing default value for subject fixes all issues above and works
fine.