### PR TITLE
Replaced feathers.static with express.static

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ app.configure(express.rest())
  .configure(local())
  .configure(jwt())
  .use('/users', memory())
- .use('/', feathers.static(__dirname + '/public'))
+ .use('/', express.static(__dirname + '/public'))
  .use(express.errorHandler());
 
 app.service('users').hooks({


### PR DESCRIPTION
### Summary

The quick example contained in the README fails to run. In Buzzard, `feathersjs/express` contains the Express built-in middleware like `express.static`. This change updates the README to match the new Buzzard API.

There are no open issues related to this change, and this change is not dependent on any other PRs.