### PR TITLE
Remove subject from the JWT verification options

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,7 +58,6 @@ exports.verifyJWT = function verifyJWT (token, options = {}) {
     'issuer',
     'ignoreExpiration',
     'ignoreNotBefore',
-    'subject',
     'clockTolerance'
   ];
   const settings = merge({}, options.jwt);


### PR DESCRIPTION
As discussed in #684, the current default for subject causes token
verification to fail if sub is overriden.

Removing subject from default options might be a breaking change as
people might rely on it.

Remove subject from verification options, so it's not checked. This is
a safer way.